### PR TITLE
fix: global stores

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,6 +1,7 @@
 import "unplugin-icons/types/svelte";
 import { DefaultSession } from "@auth/core";
 import type { AvailableLanguageTag } from "$paraglide/runtime";
+import type { Theme } from "$lib/stores/theme";
 
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
@@ -9,6 +10,7 @@ declare global {
     // interface Error {}
     interface Locals {
       lang: AvailableLanguageTag;
+      theme: Theme;
     }
     // interface PageData {}
     // interface Platform {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,10 +1,10 @@
 import { SvelteKitAuth } from "@auth/sveltekit";
 import GitHub from "@auth/core/providers/github";
 import { env } from "$env/dynamic/private";
-import { detectLanguage } from "$lib/stores/i18n";
+import { serverDetectLanguage } from "$lib/stores/i18n";
+import { serverDetectTheme } from "$lib/stores/theme";
 import { sequence } from "@sveltejs/kit/hooks";
 import type { Handle } from "@sveltejs/kit";
-import { detectTheme } from "$lib/stores/theme";
 
 const admins = env.ADMINS?.split(",")
   .map((s) => s.trim())
@@ -39,7 +39,7 @@ const auth = SvelteKitAuth({
 });
 
 const locale: Handle = async ({ event, resolve }) => {
-  const lang = detectLanguage(event.url, event.request);
+  const lang = serverDetectLanguage(event.url, event.request);
 
   event.locals.lang = lang;
 
@@ -53,19 +53,19 @@ const locale: Handle = async ({ event, resolve }) => {
   });
 };
 
-const theme: Handle = async ({event, resolve}) => {
-  const theme = detectTheme(event.request);
+const theme: Handle = async ({ event, resolve }) => {
+  const theme = serverDetectTheme(event.request);
 
   event.locals.theme = theme;
 
   const response = await resolve(event);
-  
+
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-Prefers-Color-Scheme
   response.headers.set("Accept-CH", "Sec-CH-Prefers-Color-Scheme");
   response.headers.set("Vary", "Sec-CH-Prefers-Color-Scheme");
   response.headers.set("Critical-CH", "Sec-CH-Prefers-Color-Scheme");
 
   return response;
-}
+};
 
 export const handle = sequence(auth, locale, theme);

--- a/src/lib/stores/contextStore.ts
+++ b/src/lib/stores/contextStore.ts
@@ -1,4 +1,3 @@
-
 import { getContext, hasContext, setContext } from "svelte";
 
 /**
@@ -8,15 +7,15 @@ import { getContext, hasContext, setContext } from "svelte";
  * @see {@link https://dev.to/brendanmatkin/safe-sveltekit-stores-for-ssr-5a0h}
  */
 export const useContextStore = <T, TStore>(
-    name: string,
-    fn: (value?: T) => TStore,
-    defaultValue?: T,
+  name: string,
+  createStore: (value?: T) => TStore,
+  defaultValue?: T
 ): TStore => {
   // INFO: `TStore` is not constrained to `Readable<T>`, to be more flexible (with the objects)
-    if (hasContext(name)) {
-        return getContext<TStore>(name);
-    }
-    const _value = fn(defaultValue);
-    setContext(name, _value);
-    return _value;
+  if (hasContext(name)) {
+    return getContext<TStore>(name);
+  }
+  const store = createStore(defaultValue);
+  setContext(name, store);
+  return store;
 };

--- a/src/lib/stores/contextStore.ts
+++ b/src/lib/stores/contextStore.ts
@@ -1,0 +1,22 @@
+
+import { getContext, hasContext, setContext } from "svelte";
+
+/**
+ * Get value from a `ContextStore`, which is created for each user, and save for SSR.
+ *
+ * Implementation by Brendan Matkin, on `dev.to`.
+ * @see {@link https://dev.to/brendanmatkin/safe-sveltekit-stores-for-ssr-5a0h}
+ */
+export const useContextStore = <T, TStore>(
+    name: string,
+    fn: (value?: T) => TStore,
+    defaultValue?: T,
+): TStore => {
+  // INFO: `TStore` is not constrained to `Readable<T>`, to be more flexible (with the objects)
+    if (hasContext(name)) {
+        return getContext<TStore>(name);
+    }
+    const _value = fn(defaultValue);
+    setContext(name, _value);
+    return _value;
+};

--- a/src/lib/stores/i18n.ts
+++ b/src/lib/stores/i18n.ts
@@ -8,16 +8,34 @@ import {
 } from "$paraglide/runtime";
 import * as m from "$paraglide/messages";
 
+/**
+ * A type returned by {@link i18nStores()}, containing 2 Svelte stores.
+ */
 export type I18nStores = {
+  /** Containing the current language tag, you can set a new language here. */
   lang: Omit<Writable<AvailableLanguageTag>, "update">;
+  /** A readonly store containing i18n messages, and is reactive the changes of the current language. */
   m: Readable<typeof m>;
 };
 
+/**
+ * Returns a string URL that contains `lang=[lang]` search param.
+ * @param url The current URl
+ * @param lang The target language
+ */
 export function langUrl(url: URL, lang: AvailableLanguageTag): string {
   url.searchParams.set("lang", lang);
   return url.toString();
 }
 
+/**
+ * Get {@link I18nStores} from a default language tag.
+ * Where {@link I18nStores.lang} is the current language,
+ * {@link I18nStores.m} is the i18n messages.
+ *
+ * When the langauge is set (on {@link I18nStores.lang}),
+ * the 2 stores will both get updated (event fired).
+ */
 export function i18nStores(lang: AvailableLanguageTag): I18nStores {
   const { set, subscribe } = writable<AvailableLanguageTag>(lang);
   const { subscribe: subscribeM, update: updateM } = writable<typeof m>(m);
@@ -37,6 +55,11 @@ export function i18nStores(lang: AvailableLanguageTag): I18nStores {
   return { lang: { set, subscribe }, m: { subscribe: subscribeM } };
 }
 
+/**
+ * Detect user's current language by the request URL and `Accept-Language` header.
+ * @param url User's URL to determine the requested language ('lang=[lang]')
+ * @param request The {@link Request} object, containing the headers
+ */
 export function detectLanguage(url?: URL, request?: Request): AvailableLanguageTag {
   const requestLang = requestLanguage(request);
   const browserLang = browser ? window.localStorage.getItem("lang") : undefined;
@@ -44,6 +67,9 @@ export function detectLanguage(url?: URL, request?: Request): AvailableLanguageT
   return getLang(url?.searchParams.get("lang") ?? browserLang ?? requestLang ?? "");
 }
 
+/**
+ * Detect user's requesting language by the `Accept-Language` header, from an {@link Request} object.
+ */
 function requestLanguage(request?: Request): AvailableLanguageTag | undefined {
   type LanguageWeight = { tag: AvailableLanguageTag; weight: number };
 
@@ -64,6 +90,9 @@ function requestLanguage(request?: Request): AvailableLanguageTag | undefined {
   // INFO: accessing [0] of the array might be `undefined`
 }
 
+/**
+ * Guarantees an available language by replacing invalid ones with the default
+ */
 function getLang(lang: string): AvailableLanguageTag {
   return isAvailableLanguageTag(lang) ? lang : sourceLanguageTag;
 }

--- a/src/lib/stores/i18n.ts
+++ b/src/lib/stores/i18n.ts
@@ -57,7 +57,7 @@ export function serverDetectLanguage(url: URL, request: Request): AvailableLangu
 }
 
 /**
- * Detect user's current language by the URL and the result from {@link serverDetectLanguage}.
+ * Detect user's current language by client data and the result from {@link serverDetectLanguage}.
  *
  * Note that though this function is intended to be run on the 'page',
  * it may still run on the server for SSR.

--- a/src/lib/stores/i18n.ts
+++ b/src/lib/stores/i18n.ts
@@ -44,6 +44,19 @@ export function useI18nStores(lang?: AvailableLanguageTag): I18nStores {
   return useContextStore("i18n", i18nStores, lang);
 }
 
+
+/**
+ * Detect user's current language by the request URL and `Accept-Language` header.
+ * @param url User's URL to determine the requested language ('lang=[lang]')
+ * @param request The {@link Request} object, containing the headers
+ */
+export function detectLanguage(url?: URL, request?: Request): AvailableLanguageTag {
+  const requestLang = requestLanguage(request);
+  const browserLang = browser ? window.localStorage.getItem("lang") : undefined;
+
+  return getLang(url?.searchParams.get("lang") ?? browserLang ?? requestLang ?? "");
+}
+
 /**
  * Get {@link I18nStores} from a default language tag.
  * Where {@link I18nStores.lang} is the current language,
@@ -69,18 +82,6 @@ function i18nStores(lang?: AvailableLanguageTag): I18nStores {
   });
 
   return { lang: { set, subscribe }, m: { subscribe: subscribeM } };
-}
-
-/**
- * Detect user's current language by the request URL and `Accept-Language` header.
- * @param url User's URL to determine the requested language ('lang=[lang]')
- * @param request The {@link Request} object, containing the headers
- */
-export function detectLanguage(url?: URL, request?: Request): AvailableLanguageTag {
-  const requestLang = requestLanguage(request);
-  const browserLang = browser ? window.localStorage.getItem("lang") : undefined;
-
-  return getLang(url?.searchParams.get("lang") ?? browserLang ?? requestLang ?? "");
 }
 
 /**

--- a/src/lib/stores/i18n.ts
+++ b/src/lib/stores/i18n.ts
@@ -50,11 +50,14 @@ function requestLanguage(request?: Request): AvailableLanguageTag | undefined {
   return (request?.headers.get("Accept-Language") ?? "")
     .split(",")
     .map((lang) => {
-      const [tag, weight] = lang.split(";");
+      let [tag, weight] = lang.split(";");
+
+      tag = tag.trim();
+      weight = weight?.trim().substring(2) ?? "1";
 
       if (!isAvailableLanguageTag(tag)) return undefined;
 
-      return { tag, weight: parseFloat(weight.substring(2)) } as LanguageWeight;
+      return { tag, weight: parseFloat(weight) } as LanguageWeight;
     })
     .filter((e): e is LanguageWeight => Boolean(e))
     .toSorted((a, b) => b.weight - a.weight)[0]?.tag;

--- a/src/lib/stores/i18n.ts
+++ b/src/lib/stores/i18n.ts
@@ -44,17 +44,32 @@ export function useI18nStores(lang?: AvailableLanguageTag): I18nStores {
   return useContextStore("i18n", i18nStores, lang);
 }
 
-
 /**
- * Detect user's current language by the request URL and `Accept-Language` header.
+ * Detect user's current language by the request URL and `Accept-Language` header *on the server*.
  * @param url User's URL to determine the requested language ('lang=[lang]')
  * @param request The {@link Request} object, containing the headers
  */
-export function detectLanguage(url?: URL, request?: Request): AvailableLanguageTag {
+export function serverDetectLanguage(url: URL, request: Request): AvailableLanguageTag {
+  const urlLang = url.searchParams.get("lang");
   const requestLang = requestLanguage(request);
+
+  return getLang(urlLang ?? requestLang ?? "");
+}
+
+/**
+ * Detect user's current language by the URL and the result from {@link serverDetectLanguage}.
+ *
+ * Note that though this function is intended to be run on the 'page',
+ * it may still run on the server for SSR.
+ *
+ * @param serverLangauge Language detected from the server, with consideration of the request header
+ * @param url Page's URL to get searchParam
+ */
+export function pageDetectLanguage(serverLangauge: AvailableLanguageTag, url: URL) {
+  const urlLang = url.searchParams.get("lang");
   const browserLang = browser ? window.localStorage.getItem("lang") : undefined;
 
-  return getLang(url?.searchParams.get("lang") ?? browserLang ?? requestLang ?? "");
+  return getLang(urlLang ?? browserLang ?? serverLangauge);
 }
 
 /**

--- a/src/lib/stores/i18n.ts
+++ b/src/lib/stores/i18n.ts
@@ -36,8 +36,8 @@ export function langUrl(url: URL, lang: AvailableLanguageTag): string {
  * When the langauge is set (on {@link I18nStores.lang}),
  * the 2 stores will both get updated (event fired).
  */
-export function i18nStores(lang: AvailableLanguageTag): I18nStores {
-  const { set, subscribe } = writable<AvailableLanguageTag>(lang);
+export function i18nStores(lang?: AvailableLanguageTag): I18nStores {
+  const { set, subscribe } = writable<AvailableLanguageTag>(lang ?? sourceLanguageTag);
   const { subscribe: subscribeM, update: updateM } = writable<typeof m>(m);
 
   subscribe((lang) => {

--- a/src/lib/stores/i18n.ts
+++ b/src/lib/stores/i18n.ts
@@ -7,6 +7,7 @@ import {
   type AvailableLanguageTag
 } from "$paraglide/runtime";
 import * as m from "$paraglide/messages";
+import { useContextStore } from "./contextStore";
 
 /**
  * A type returned by {@link i18nStores()}, containing 2 Svelte stores.
@@ -29,6 +30,21 @@ export function langUrl(url: URL, lang: AvailableLanguageTag): string {
 }
 
 /**
+ * Get an {@link I18nStores} instance from the `Context`.
+ * Creates the store if not found.
+ *
+ * When the langauge is set on {@link I18nStores.lang},
+ * {@link I18nStores.m} also gets the update.
+ *
+ * @see {@link useContextStore()}
+ *
+ * @param lang The default language used if creating a new {@link I18nStores}, usually only specified in `+layout.svelte`.
+ */
+export function useI18nStores(lang?: AvailableLanguageTag): I18nStores {
+  return useContextStore("i18n", i18nStores, lang);
+}
+
+/**
  * Get {@link I18nStores} from a default language tag.
  * Where {@link I18nStores.lang} is the current language,
  * {@link I18nStores.m} is the i18n messages.
@@ -36,7 +52,7 @@ export function langUrl(url: URL, lang: AvailableLanguageTag): string {
  * When the langauge is set (on {@link I18nStores.lang}),
  * the 2 stores will both get updated (event fired).
  */
-export function i18nStores(lang?: AvailableLanguageTag): I18nStores {
+function i18nStores(lang?: AvailableLanguageTag): I18nStores {
   const { set, subscribe } = writable<AvailableLanguageTag>(lang ?? sourceLanguageTag);
   const { subscribe: subscribeM, update: updateM } = writable<typeof m>(m);
 

--- a/src/lib/stores/theme.ts
+++ b/src/lib/stores/theme.ts
@@ -5,16 +5,36 @@ import { useContextStore } from "./contextStore";
 
 export type Theme = "light" | "dark";
 
+/**
+ * Get the current {@link Theme} from the `Context`.
+ * Creates the store if not found.
+ *
+ * @see {@link useContextStore()}
+ *
+ * @param lang The default theme used if creating a new store, usually only specified in `+layout.svelte`.
+ */
 export function useThemeStore(theme: Theme) {
   return useContextStore("theme", themeStore, theme);
 }
 
+/**
+ * Detect user's current theme by the request header *on the server*.
+ * @param request The {@link Request} object, containing the headers
+ */
 export function serverDetectTheme(request: Request): Theme {
   const requestTheme = request.headers.get("Sec-CH-Prefers-Color-Scheme") as Theme | null;
 
   return requestTheme ?? "dark";
 }
 
+/**
+ * Detect user's current theme by client data and the result from {@link serverDetectTheme}.
+ *
+ * Note that though this function is intended to be run on the 'page',
+ * it may still run on the server for SSR.
+ *
+ * @param serverTheme Theme detected from the server, with consideration of the request header
+ */
 export function pageDetectTheme(serverTheme: Theme): Theme {
   const browserTheme = browser ? window.localStorage.getItem("theme") == "light" : undefined;
   const mediaTheme = browser ? window.matchMedia("(prefers-color-scheme: light)").matches : undefined;
@@ -22,6 +42,10 @@ export function pageDetectTheme(serverTheme: Theme): Theme {
   return (browserTheme ?? mediaTheme ?? serverTheme == "light") ? "light" : "dark";
 }
 
+/**
+  * Create a theme store with an optional default value,
+  * setup side effects e.g. setting the `dark` class
+  */
 function themeStore(theme?: Theme) {
   const mediaMatch = browser ? window.matchMedia("(prefers-color-scheme: light)") : undefined;
 

--- a/src/lib/stores/theme.ts
+++ b/src/lib/stores/theme.ts
@@ -37,15 +37,17 @@ export function serverDetectTheme(request: Request): Theme {
  */
 export function pageDetectTheme(serverTheme: Theme): Theme {
   const browserTheme = browser ? window.localStorage.getItem("theme") == "light" : undefined;
-  const mediaTheme = browser ? window.matchMedia("(prefers-color-scheme: light)").matches : undefined;
+  const mediaTheme = browser
+    ? window.matchMedia("(prefers-color-scheme: light)").matches
+    : undefined;
 
-  return (browserTheme ?? mediaTheme ?? serverTheme == "light") ? "light" : "dark";
+  return browserTheme ?? mediaTheme ?? serverTheme == "light" ? "light" : "dark";
 }
 
 /**
-  * Create a theme store with an optional default value,
-  * setup side effects e.g. setting the `dark` class
-  */
+ * Create a theme store with an optional default value,
+ * setup side effects e.g. setting the `dark` class
+ */
 function themeStore(theme?: Theme) {
   const mediaMatch = browser ? window.matchMedia("(prefers-color-scheme: light)") : undefined;
 

--- a/src/lib/stores/theme.ts
+++ b/src/lib/stores/theme.ts
@@ -9,12 +9,17 @@ export function useThemeStore(theme: Theme) {
   return useContextStore("theme", themeStore, theme);
 }
 
-export function detectTheme(request?: Request): Theme {
-  const requestTheme = request?.headers.get("Sec-CH-Prefers-Color-Scheme") == "light";
-  const browserTheme = browser ? window.localStorage.getItem("theme") == "light" : false;
-  const mediaTheme = browser ? window.matchMedia("(prefers-color-scheme: light)").matches : false;
+export function serverDetectTheme(request: Request): Theme {
+  const requestTheme = request.headers.get("Sec-CH-Prefers-Color-Scheme") as Theme | null;
 
-  return (browserTheme && mediaTheme && requestTheme) ? "light" : "dark";
+  return requestTheme ?? "dark";
+}
+
+export function pageDetectTheme(serverTheme: Theme): Theme {
+  const browserTheme = browser ? window.localStorage.getItem("theme") == "light" : undefined;
+  const mediaTheme = browser ? window.matchMedia("(prefers-color-scheme: light)").matches : undefined;
+
+  return (browserTheme ?? mediaTheme ?? serverTheme == "light") ? "light" : "dark";
 }
 
 function themeStore(theme?: Theme) {

--- a/src/lib/stores/theme.ts
+++ b/src/lib/stores/theme.ts
@@ -3,15 +3,21 @@ import { writable } from "svelte/store";
 import { browser } from "$app/environment";
 import { useContextStore } from "./contextStore";
 
+export type Theme = "light" | "dark";
+
 export function useThemeStore() {
   return useContextStore("theme", themeStore);
 }
 
-export function themeStore() {
+export function detectTheme(): Theme {
+
+}
+
+function themeStore() {
   const storageTheme = browser ? window.localStorage.getItem("theme") : undefined;
   const mediaMatch = browser ? window.matchMedia("(prefers-color-scheme: light)") : undefined;
 
-  const { set, subscribe, update } = writable<"light" | "dark">(
+  const { set, subscribe, update } = writable<Theme>(
     storageTheme === "light" || mediaMatch?.matches ? "light" : "dark"
   );
 

--- a/src/lib/stores/theme.ts
+++ b/src/lib/stores/theme.ts
@@ -9,8 +9,12 @@ export function useThemeStore() {
   return useContextStore("theme", themeStore);
 }
 
-export function detectTheme(): Theme {
+export function detectTheme(request: Request): Theme {
+  const requestTheme = request.headers.get("Sec-CH-Prefers-Color-Scheme") == "light";
+  const browserTheme = browser ? window.localStorage.getItem("theme") == "light" : false;
+  const mediaTheme = browser ? window.matchMedia("(prefers-color-scheme: light)").matches : false;
 
+  return (browserTheme && mediaTheme && requestTheme) ? "light" : "dark";
 }
 
 function themeStore() {

--- a/src/lib/stores/theme.ts
+++ b/src/lib/stores/theme.ts
@@ -1,6 +1,11 @@
 // SAVE CURRENT THEME
 import { writable } from "svelte/store";
 import { browser } from "$app/environment";
+import { useContextStore } from "./contextStore";
+
+export function useThemeStore() {
+  return useContextStore("theme", themeStore);
+}
 
 export function themeStore() {
   const storageTheme = browser ? window.localStorage.getItem("theme") : undefined;

--- a/src/lib/stores/theme.ts
+++ b/src/lib/stores/theme.ts
@@ -2,7 +2,7 @@
 import { writable } from "svelte/store";
 import { browser } from "$app/environment";
 
-function getThemeStore() {
+export function themeStore() {
   const storageTheme = browser ? window.localStorage.getItem("theme") : undefined;
   const mediaMatch = browser ? window.matchMedia("(prefers-color-scheme: light)") : undefined;
 
@@ -29,5 +29,3 @@ function getThemeStore() {
     toggle: () => update((current) => (current === "light" ? "dark" : "light"))
   };
 }
-
-export const themeStore = getThemeStore();

--- a/src/lib/stores/theme.ts
+++ b/src/lib/stores/theme.ts
@@ -5,25 +5,22 @@ import { useContextStore } from "./contextStore";
 
 export type Theme = "light" | "dark";
 
-export function useThemeStore() {
-  return useContextStore("theme", themeStore);
+export function useThemeStore(theme: Theme) {
+  return useContextStore("theme", themeStore, theme);
 }
 
-export function detectTheme(request: Request): Theme {
-  const requestTheme = request.headers.get("Sec-CH-Prefers-Color-Scheme") == "light";
+export function detectTheme(request?: Request): Theme {
+  const requestTheme = request?.headers.get("Sec-CH-Prefers-Color-Scheme") == "light";
   const browserTheme = browser ? window.localStorage.getItem("theme") == "light" : false;
   const mediaTheme = browser ? window.matchMedia("(prefers-color-scheme: light)").matches : false;
 
   return (browserTheme && mediaTheme && requestTheme) ? "light" : "dark";
 }
 
-function themeStore() {
-  const storageTheme = browser ? window.localStorage.getItem("theme") : undefined;
+function themeStore(theme?: Theme) {
   const mediaMatch = browser ? window.matchMedia("(prefers-color-scheme: light)") : undefined;
 
-  const { set, subscribe, update } = writable<Theme>(
-    storageTheme === "light" || mediaMatch?.matches ? "light" : "dark"
-  );
+  const { set, subscribe, update } = writable<Theme>(theme ?? "dark");
 
   subscribe((theme) => {
     if (!browser) return;

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -5,6 +5,7 @@ import type { LayoutServerLoad } from "./$types";
 export const load: LayoutServerLoad = async (event) => {
   return {
     session: await event.locals.getSession(),
-    lang: event.locals.lang
+    lang: event.locals.lang,
+    theme: event.locals.theme
   };
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,8 +6,8 @@
   import { fly } from "svelte/transition";
   import { base } from "$app/paths";
   import { page } from "$app/stores";
-  import { useThemeStore } from "$lib/stores/theme";
-  import { detectLanguage, useI18nStores, langUrl } from "$lib/stores/i18n";
+  import { pageDetectTheme, useThemeStore } from "$lib/stores/theme";
+  import { pageDetectLanguage, useI18nStores, langUrl } from "$lib/stores/i18n";
   import { availableLanguageTags } from "$paraglide/runtime";
 
   // Icon
@@ -21,13 +21,14 @@
 
   export let data;
 
-  const { session, lang, theme: defaultTheme } = data;
+  const { session, lang: serverLang, theme: serverTheme } = data;
 
-  const i18n = useI18nStores(lang);
-  const theme = useThemeStore(defaultTheme);
+  const i18n = useI18nStores(pageDetectLanguage(serverLang, $page.url));
+  const theme = useThemeStore(pageDetectTheme(serverTheme));
 
-  // reactively set the page's language
-  $: i18n.lang.set(detectLanguage($page.url));
+  // reactively set the global stores
+  $: i18n.lang.set(pageDetectLanguage(serverLang, $page.url));
+  $: theme.set(pageDetectTheme(serverTheme));
   const m = i18n.m;
 
   // TODO: scroll detection & changing title

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,7 +7,8 @@
   import { base } from "$app/paths";
   import { page } from "$app/stores";
   import { themeStore } from "$lib/stores/theme";
-  import { detectLanguage, langUrl } from "$lib/stores/i18n";
+  import { detectLanguage, i18nStores, langUrl } from "$lib/stores/i18n";
+  import { useContextStore } from "$lib/stores/contextStore";
   import { availableLanguageTags } from "$paraglide/runtime";
 
   // Icon
@@ -18,16 +19,16 @@
   import Earth from "~icons/mdi/earth";
   import ChevronRight from "~icons/mdi/chevron-right";
   import logo from "$lib/assets/logo.svg";
-  import { setContext } from "svelte";
 
   export let data;
 
-  const { session, i18n } = data;
+  const { session, lang } = data;
+
+  const i18n = useContextStore("i18n", i18nStores, lang);
+  const theme = useContextStore("theme", themeStore);
 
   $: i18n.lang.set(detectLanguage($page.url));
   const m = i18n.m;
-
-  setContext("i18n", i18n);
 
   // TODO: scroll detection & changing title
 
@@ -51,9 +52,9 @@
     <a href="{base}/" class="flex items-center gap-2 overflow-hidden">
       <img src={logo} class="h-12 w-12" alt="TNFSHCEC icon" />
       <div>
-        <span class="font-bold whitespace-nowrap">{$m.title()}</span>
+        <span class="whitespace-nowrap font-bold">{$m.title()}</span>
         <br />
-        <span class="text-xl font-bold whitespace-nowrap">{$m.name()}</span>
+        <span class="whitespace-nowrap text-xl font-bold">{$m.name()}</span>
       </div>
     </a>
     <button
@@ -76,9 +77,9 @@
         <div
           use:melt={$item}
           class="icon-flex rounded-t px-4 py-2 transition-colors hover:bg-primary/20"
-          on:m-click={() => themeStore.toggle()}
+          on:m-click={() => theme.toggle()}
         >
-          {#if $themeStore === "light"}
+          {#if $theme === "light"}
             <Brightness class="h-4 w-4" />
             <span>{$m.lightTheme()}</span>
           {:else}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -21,10 +21,10 @@
 
   export let data;
 
-  const { session, lang } = data;
+  const { session, lang, theme: defaultTheme } = data;
 
   const i18n = useI18nStores(lang);
-  const theme = useThemeStore();
+  const theme = useThemeStore(defaultTheme);
 
   // reactively set the page's language
   $: i18n.lang.set(detectLanguage($page.url));

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,9 +6,8 @@
   import { fly } from "svelte/transition";
   import { base } from "$app/paths";
   import { page } from "$app/stores";
-  import { themeStore } from "$lib/stores/theme";
-  import { detectLanguage, i18nStores, langUrl } from "$lib/stores/i18n";
-  import { useContextStore } from "$lib/stores/contextStore";
+  import { useThemeStore } from "$lib/stores/theme";
+  import { detectLanguage, useI18nStores, langUrl } from "$lib/stores/i18n";
   import { availableLanguageTags } from "$paraglide/runtime";
 
   // Icon
@@ -24,9 +23,10 @@
 
   const { session, lang } = data;
 
-  const i18n = useContextStore("i18n", i18nStores, lang);
-  const theme = useContextStore("theme", themeStore);
+  const i18n = useI18nStores(lang);
+  const theme = useThemeStore();
 
+  // reactively set the page's language
   $: i18n.lang.set(detectLanguage($page.url));
   const m = i18n.m;
 

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,9 +1,0 @@
-import { i18nStores } from "$lib/stores/i18n";
-import type { LayoutLoad } from "./$types";
-
-export const load = (({ data }) => {
-  return {
-    ...data,
-    i18n: i18nStores(data.lang)
-  };
-}) satisfies LayoutLoad;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-
   // svelte
   import { base } from "$app/paths";
   import type { ComponentProps } from "svelte";
@@ -18,9 +17,10 @@
   import Comment from "$lib/components/Comment.svelte";
   import PostCard from "$lib/components/PostCard.svelte";
   import { anchorScroll } from "$lib/components/actions";
+  import { useI18nStores } from "$lib/stores/i18n";
 
   export let data;
-  const m = data.i18n.m;
+  const { m } = useI18nStores();
 
   // comments
   const comments: ComponentProps<Comment>[][] = [

--- a/src/routes/post/+page.svelte
+++ b/src/routes/post/+page.svelte
@@ -2,9 +2,10 @@
 <script lang="ts">
   import PageTitle from "$lib/components/PageTitle.svelte";
   import PostCard from "$lib/components/PostCard.svelte";
+  import { useI18nStores } from "$lib/stores/i18n.js";
 
   export let data;
-  const m = data.i18n.m;
+  const { m } = useI18nStores();
 </script>
 
 <div class="w-full p-4">
@@ -22,3 +23,4 @@
     </div>
   </div>
 </div>
+

--- a/src/routes/post/+page.svelte
+++ b/src/routes/post/+page.svelte
@@ -2,7 +2,7 @@
 <script lang="ts">
   import PageTitle from "$lib/components/PageTitle.svelte";
   import PostCard from "$lib/components/PostCard.svelte";
-  import { useI18nStores } from "$lib/stores/i18n.js";
+  import { useI18nStores } from "$lib/stores/i18n";
 
   export let data;
   const { m } = useI18nStores();
@@ -23,4 +23,3 @@
     </div>
   </div>
 </div>
-

--- a/src/routes/post/[...post]/+page.svelte
+++ b/src/routes/post/[...post]/+page.svelte
@@ -14,7 +14,7 @@
   import { localeDateFromString } from "$lib/utils/date";
   import { base } from "$app/paths";
   import { fade, fly } from "svelte/transition";
-  import { useI18nStores } from "$lib/stores/i18n.js";
+  import { useI18nStores } from "$lib/stores/i18n";
 
   export let data;
   const { m } = useI18nStores();

--- a/src/routes/post/[...post]/+page.svelte
+++ b/src/routes/post/[...post]/+page.svelte
@@ -14,9 +14,10 @@
   import { localeDateFromString } from "$lib/utils/date";
   import { base } from "$app/paths";
   import { fade, fly } from "svelte/transition";
+  import { useI18nStores } from "$lib/stores/i18n.js";
 
   export let data;
-  const m = data.i18n.m;
+  const { m } = useI18nStores();
 
   // extract data
   let {

--- a/src/routes/post/[...post]/edit/+page.svelte
+++ b/src/routes/post/[...post]/edit/+page.svelte
@@ -1,23 +1,26 @@
 <script lang="ts">
+  // JS
   import { createDialog, melt } from "@melt-ui/svelte";
   import { base } from "$app/paths";
   import { applyAction, deserialize } from "$app/forms";
   import { goto } from "$app/navigation";
   import { fade, fly } from "svelte/transition";
   import { writable } from "svelte/store";
+  import { useI18nStores } from "$lib/stores/i18n";
+  import { localeDateFromString } from "$lib/utils/date";
+  import { nextUpdate } from "$lib/utils/nextStoreUpdate";
 
+  // components
   import Carta from "$lib/components/Carta.svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
   import CenteredPage from "$lib/components/CenteredPage.svelte";
-  import { editField } from "$lib/components/actions";
-  import { localeDateFromString } from "$lib/utils/date";
-  import { nextUpdate } from "$lib/utils/nextStoreUpdate";
   import { addToast } from "$lib/components/Toaster.svelte";
+  import { editField } from "$lib/components/actions";
 
+  // icons
   import Pin from "~icons/mdi/pin";
   import Save from "~icons/mdi/content-save-edit";
   import Alert from "~icons/mdi/alert";
-  import { useI18nStores } from "$lib/stores/i18n.js";
 
   export let data;
 

--- a/src/routes/post/[...post]/edit/+page.svelte
+++ b/src/routes/post/[...post]/edit/+page.svelte
@@ -17,11 +17,12 @@
   import Pin from "~icons/mdi/pin";
   import Save from "~icons/mdi/content-save-edit";
   import Alert from "~icons/mdi/alert";
+  import { useI18nStores } from "$lib/stores/i18n.js";
 
   export let data;
 
-  let { md, data: postData, i18n } = data;
-  const m = i18n.m;
+  let { md, data: postData } = data;
+  const { m } = useI18nStores();
   $: localeDate = localeDateFromString(postData.date ?? "");
 
   let editUrl = postData.url;


### PR DESCRIPTION
- [x] 解決 `i18nStore` 的邏輯問題
- [x] 新增 `useContextStore` 幫助建立其他 store
- [x] 用上面的 `useContextStore` 新增了 `useI18nStores`, `useThemeStore`
  - 解決 `themeStore` 直接儲存資料在 server 上的問題
- [x] 寫了 documentation
- [x] 在 server 偵測用戶使用的是亮色或暗色 （[MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-Prefers-Color-Scheme)，Firefox 還不支援）

---

那個 `use` 還真有 `react` 的韻味