### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,10 @@
     "@cartamd/plugin-code": "^3.0.1",
     "carta-md": "^3.1.3",
     "fast-glob": "^3.3.0",
-    "highlight.js": "^11.9.0",
     "js-yaml": "^4.1.0",
     "lru-cache": "^10.0.1",
     "marked-footnote": "^1.1.3",
-    "rehype-raw": "^7.0.0",
-    "rehype-slug": "^6.0.0",
     "thunky": "^1.1.0",
-    "unist-util-visit": "^5.0.0",
     "yaml-front-matter": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
reduces the bundle size by 1mB (i think)