### PR TITLE
fix: markdown image processing

### DIFF
--- a/cec/test/imagetest.md
+++ b/cec/test/imagetest.md
@@ -1,5 +1,6 @@
 ---
 title: Multi-Image Test
+unlisted: true
 ---
 
 Regular images should be extracted out of the `<p>` tags normally placed around them.

--- a/cec/test/imagetest.md
+++ b/cec/test/imagetest.md
@@ -1,0 +1,17 @@
+---
+title: Multi-Image Test
+---
+
+Regular images should be extracted out of the `<p>` tags normally placed around them.
+
+![Super Abstract](./test-image.png "Super Abstract yaaaa")
+
+Images placed within paragraphs should also display correctly.  
+Even with multiple images, each should be separated, and any text between them should form its own paragraph.
+
+![Super Abstract](./test-image.png "Super Abstract yaaaa")
+Here is some text between the images.
+![Super Abstract](./test-image.png)
+Just like this :)))
+
+All the text above is part of the same block—check the markdown source to see!

--- a/mdsvex.config.js
+++ b/mdsvex.config.js
@@ -32,9 +32,28 @@ const remarkAlerts = () => (tree) =>
   );
 
 const rehypeImage = () => (tree) => {
-  visit(tree, "element", (node) => {
+  visit(tree, "element", (node, index, parent) => {
+    // look for images generated inside <p> tags
+    const images = node.children?.filter(
+      (child) => child.tagName === "Components.img" && child.properties.src?.startsWith("./")
+    );
+
+    // if found image move it out of the <p>
+    if (images && images.length > 0) {
+      const pIndex = parent.children.indexOf(node);
+      parent.children.splice(pIndex + 1, 0, ...images);
+
+      for (let img of images) {
+        const imgIndex = node.children.indexOf(img);
+        node.children.splice(imgIndex, 1);
+      }
+
+      // console.log(parent);
+    }
+
     if (node.properties.src?.startsWith("./")) {
       // test if src is a relative path by checking "./"
+      // console.log(node)
       node.properties.src = `{new URL('${node.properties.src}', import.meta.url).href}`;
     }
   });

--- a/src/lib/components/svx/Image.svelte
+++ b/src/lib/components/svx/Image.svelte
@@ -8,20 +8,6 @@
   }
 
   let { src = "", alt = "", title = undefined }: Props = $props();
-
-  // WARN: dirty workaround (see mdsvex.config.js)
-  // since i am lazy and used the vite URL method to import static assets,
-  // which does not support ssr environment,
-  // we need to prevent the server-rendered `file:///` src from showing.
-  // and the below code is purely recommended by the svelte docs to update attributes after hydration.
-
-  const initial = src;
-  src = "";
-
-  $effect(() => {
-    // reset after mounted
-    src = initial;
-  });
 </script>
 
 <figure>

--- a/src/lib/components/svx/Image.svelte
+++ b/src/lib/components/svx/Image.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { browser } from "$app/environment";
-
   interface Props {
     src?: string;
     alt?: string;

--- a/src/lib/components/svx/Image.svelte
+++ b/src/lib/components/svx/Image.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { browser } from "$app/environment";
+
   interface Props {
     src?: string;
     alt?: string;
@@ -6,6 +8,20 @@
   }
 
   let { src = "", alt = "", title = undefined }: Props = $props();
+
+  // WARN: dirty workaround (see mdsvex.config.js)
+  // since i am lazy and used the vite URL method to import static assets,
+  // which does not support ssr environment,
+  // we need to prevent the server-rendered `file:///` src from showing.
+  // and the below code is purely recommended by the svelte docs to update attributes after hydration.
+
+  const initial = src;
+  src = "";
+
+  $effect(() => {
+    // reset after mounted
+    src = initial;
+  });
 </script>
 
 <figure>

--- a/tests/images.test.ts
+++ b/tests/images.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+
+test("can extract figures properly", async ({ page }) => {
+  const res = await page.goto("/post/test/imagetest");
+
+  expect(res?.ok()).toBe(true);
+
+  // the figures' parent shouldn't be <p>
+  const figures = await page.locator("figure").all();
+  for (const figure of figures) {
+    const parentTag = await figure.evaluate((el) => el.parentElement?.tagName);
+    expect(parentTag).not.toBe("p");
+  }
+
+  // the figures should be followed by a <p>
+  const figureParagraphs = await page.locator("figure + p").count();
+  expect(figureParagraphs).toBe(figures.length);
+});


### PR DESCRIPTION
As described in 60f999f, the method we were using to transform markdown images into figures with caption would cause a hard error after upgrading to Svelte 5, rendering the page blank. This PR fixes the issue.

Also, the way we handled relative paths for static assets does not support SSR, and Svelte 5 refuses to immediately change the bad src on client hydration. This is fixed with a more-rubust-but-still-cursed apporach, which is inserting import statements in `<script>` tags and generating all the ids.

I added a test for the image processing as well, though it might not be good enough to detect processing bug.

And copilot sucks everytime i use it, fun ;')