### PR TITLE
fix: localize href

### DIFF
--- a/src/lib/components/CenteredPage.svelte
+++ b/src/lib/components/CenteredPage.svelte
@@ -2,6 +2,7 @@
 <script lang="ts">
   import ChevronRight from "~icons/mdi/chevron-right";
   import * as m from "$paraglide/messages";
+  import { localizeHref } from "$paraglide/runtime";
   import { base } from "$app/paths";
   import type { Snippet } from "svelte";
 
@@ -41,7 +42,7 @@
       <span>
         {#each breadcrumb as page}
           <span class="transition-colors hover:text-accent">
-            <a href={breadcrumbPages[page].url}>
+            <a href={localizeHref(breadcrumbPages[page].url)}>
               {breadcrumbPages[page].name}
             </a>
             <ChevronRight class="inline h-4 w-4" />

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -27,7 +27,7 @@
 >
   <div class="mx-auto flex w-full max-w-6xl items-center justify-between">
     <a
-      href="{base}/"
+      href={localizeHref(`${base}/`)}
       class="grid w-full grid-cols-[2.5rem_minmax(0,1fr)] items-center gap-x-2 overflow-hidden"
     >
       <img
@@ -43,10 +43,10 @@
     <div class="my-auto ml-6 shrink-0">
       <!-- navbar buttons for larger screens -->
       <div class="hidden items-center gap-6 lg:flex">
-        <a href="{base}/post" class="shrink-0 transition-colors hover:text-accent">
+        <a href={localizeHref(`${base}/post`)} class="shrink-0 transition-colors hover:text-accent">
           {m.post_list()}
         </a>
-        <a href="{base}/post/about" class="shrink-0 transition-colors hover:text-accent">
+        <a href={localizeHref(`${base}/post/about`)} class="shrink-0 transition-colors hover:text-accent">
           {m.about()}
         </a>
         <a href="https://ctf.tnfshcec.com" class="shrink-0 transition-colors hover:text-accent">
@@ -117,14 +117,14 @@
 
             <a
               class="icon-flex w-full px-4 py-2 transition-colors hover:bg-primary/20"
-              href="{base}/post"
+              href={localizeHref(`${base}/post`)}
             >
               <Star class="h-4 w-4" />
               {m.post_list()}
             </a>
             <a
               class="icon-flex w-full px-4 py-2 transition-colors hover:bg-primary/20"
-              href="{base}/post/about"
+              href={localizeHref(`${base}/post/about`)}
             >
               <Info class="h-4 w-4" />
               {m.about()}

--- a/src/lib/components/homepage/ActivityFigure.svelte
+++ b/src/lib/components/homepage/ActivityFigure.svelte
@@ -3,6 +3,7 @@
   import { uwu } from "$lib/utils/uwu.svelte";
   import logo from "$lib/assets/logo.svg";
   import * as m from "$paraglide/messages";
+  import { localizeHref } from "$paraglide/runtime";
   import { base } from "$app/paths";
 
   let activities = [
@@ -96,7 +97,7 @@
     class="btn-accent absolute select-none whitespace-nowrap"
     style:left="19.21rem"
     style:top="3.89rem"
-    href={uwu.enabled ? `${base}/?uwu=0` : `${base}/?uwu`}
+    href={localizeHref(uwu.enabled ? `${base}/?uwu=0` : `${base}/?uwu`)}
   >
     {uwu.enabled ? "no uwu" : "uwu?"}
   </a>

--- a/src/lib/components/homepage/PostCard.svelte
+++ b/src/lib/components/homepage/PostCard.svelte
@@ -5,6 +5,7 @@
   import { fly } from "svelte/transition";
   import { localeDate } from "$lib/utils/date";
   import { goto } from "$app/navigation";
+  import { localizeHref } from "$paraglide/runtime";
 
   interface Props {
     post: App.PostData;
@@ -23,7 +24,7 @@
 
 <a
   class="grid w-full grid-cols-[1fr_fit-content(40%)] gap-2 rounded bg-secondary px-4 py-6 transition-all hover:shadow-glow hover:shadow-secondary/80 motion-safe:hover:scale-[1.01]"
-  href="{base}/post/{post.slug}"
+  href={localizeHref(`${base}/post/${post.slug}`)}
   transition:fly={{ y: 10, duration: 250 }}
 >
   <header class="icon-flex text-lg font-bold">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import { type Component } from "svelte";
   import { base } from "$app/paths";
   import { m } from "$paraglide/messages.js";
+  import { localizeHref } from "$paraglide/runtime.js";
   import { anchorScroll } from "$lib/components/actions";
   import { uwu } from "$lib/utils/uwu.svelte";
   import ActivityFigure from "$lib/components/homepage/ActivityFigure.svelte";
@@ -83,7 +84,7 @@
     <div class="max-w-lg flex-grow basis-80 space-y-4">
       <header class="text-center text-2xl font-bold">{m.home_news_title()}</header>
       <div class="text-lg">{m.home_news_description()}</div>
-      <a class="btn-accent icon-flex mx-auto w-fit" href="{base}/post">
+      <a class="btn-accent icon-flex mx-auto w-fit" href={localizeHref(`${base}/post`)}>
         <ArrowRight class="h-6 w-6" />
         <span>{m.home_news_more()}</span>
       </a>

--- a/src/routes/post/+page.svelte
+++ b/src/routes/post/+page.svelte
@@ -5,6 +5,7 @@
   import CenteredPage from "$lib/components/CenteredPage.svelte";
   import PostCard from "$lib/components/homepage/PostCard.svelte";
   import { m } from "$paraglide/messages";
+  import { localizeHref } from "$paraglide/runtime.js";
 
   let { data } = $props();
 
@@ -50,7 +51,7 @@
       <a
         class="btn-accent whitespace-nowrap
           {currentTags.includes(tag) ? '' : 'border-accent/40 text-accent/60'}"
-        href={base + getToggledHref(tag)}
+        href={localizeHref(base + getToggledHref(tag))}
       >
         #{tag}
       </a>
@@ -75,7 +76,7 @@
             <a
               class="btn-accent whitespace-nowrap
                   {currentTags.includes(tag) ? '' : 'border-accent/40 text-accent/60'}"
-              href={base + getToggledHref(tag)}
+              href={localizeHref(base + getToggledHref(tag))}
             >
               #{tag}
             </a>

--- a/src/routes/post/[...post]/+page.svelte
+++ b/src/routes/post/[...post]/+page.svelte
@@ -11,7 +11,7 @@
   import { base } from "$app/paths";
   import { fly } from "svelte/transition";
   import { m}  from "$paraglide/messages";
-  import { getLocale } from "$paraglide/runtime.js";
+  import { getLocale, localizeHref } from "$paraglide/runtime.js";
   import { localeDate } from "$lib/utils/date";
 
   let { data } = $props();
@@ -114,7 +114,7 @@
     <hr class="w-full text-text/20" />
     <div class="flex flex-wrap gap-2">
       {#each metadata.tags as tag}
-        <a class="btn-accent" href="{base}/post?tags={tag}">
+        <a class="btn-accent" href={localizeHref(`${base}/post?tags={tag}`)}>
           #{tag}
         </a>
       {/each}

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+
+import { locales } from "$paraglide/runtime";
+
+test("has anchors prefixed with locales", async ({ page }) => {
+  for (const locale of locales) {
+    await page.goto(`/${locale}`);
+    const anchors = await page.locator("a").all();
+
+    for (const anchor of anchors) {
+      const visible = await anchor.isVisible();
+      if (!visible) {
+        // skip if the anchor is not visible
+        continue;
+      }
+
+      const href = await anchor.getAttribute("href");
+      if (!href || href.startsWith("http") || href.startsWith("#")) {
+        // skip if href is null, external link, or hash link
+        continue;
+      }
+
+      expect(href).toMatch(new RegExp(`^/${locale}/?`));
+    }
+  }
+});


### PR DESCRIPTION
Since ParaglideJS 2.0, anchors are not automatically translated to the current locale, meaning that on a page of `/en`, you'll get a link to `/post`, without the en locale.

With client side routing, the page doesn't reload, making it appear fine; however, it would still be a problem just after refreshing.

And this PR just wraps every anchor we have with a `localizeHref`, which is recommended by the [ParaglideJS docs](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/basics#routing). It would become another thing to take care of, along with `base`, for every single anchor we write.

But, there is another solution. We can have a Svelte preprocessor that wraps the href's for us. The code is in the [`fix/localize-anchors-preprocessor`](https://github.com/tnfshcec/tnfshcec-web/tree/fix/localize-anchors-preprocessor) branch. It works pretty well from my (limited) testing, but there are definitely edge cases that I oversaw. So this might become a time bomb that we have to fix later.

So basically it's annoyance vs possible time bomb. We kinda have to choose.